### PR TITLE
fix: typo in update_scoreboard

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,7 @@ fn update_scoreboard(
     }
 
     if let Ok(mut ai_score) = ai_score.get_single_mut() {
-      ai_score.0 = score.player.to_string();
+      ai_score.0 = score.ai.to_string();
     }
   }
 }


### PR DESCRIPTION
Thanks for your great tutorial!

There is a mistake about setting player's score to `ai_score`. The blog also contains the mistake.